### PR TITLE
Bump DataStructures compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,13 +8,13 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-DataStructures = "0.18"
+DataStructures = ">= 0.17"
 julia = "1"
 
 [extras]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Coverage", "Documenter"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-DataStructures = "0.17"
+DataStructures = "0.18"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This is causing some conflicts with other packages (e.g. DiffEqBase.jl) for me. I ran the tests and they seemed to work on v0.18 of DataStructures.jl too.