### PR TITLE
feat(): multiple subscriptions/unsubscriptions

### DIFF
--- a/docs/src/api/teardown.md
+++ b/docs/src/api/teardown.md
@@ -41,5 +41,6 @@ unsubscribe!
 
 ```@docs
 InvalidTeardownLogicTraitUsageError
+InvalidMultipleTeardownLogicTraitUsageError
 MissingOnUnsubscribeImplementationError
 ```

--- a/docs/src/observables/about.md
+++ b/docs/src/observables/about.md
@@ -158,7 +158,23 @@ This example shows how subscribe calls are not shared among multiple Actors of t
 !!! note
     Subscribing to an Observable is like calling a function, providing callbacks where the data will be delivered to.
 
-A `subscribe!` call simply delivers initial values or events to an Actor.
+
+`subscribe!` function also supports multiple subscriptions at once. If the input argument to the `subscribe!` function is a tuple or a vector, it will first check that all of the arguments are valid source objects and actors and if its true will subscribe from each of them individually.
+
+```julia
+
+source1 = Subject(Int)
+source2 = Subject(Int)
+
+subscriptions = subscribe!([
+    (source1, logger()),
+    (source2, logger()),
+])
+
+# Later on
+# unsubscribe!(subscriptions)
+
+```
 
 ### Executing Observables
 

--- a/docs/src/teardown/about.md
+++ b/docs/src/teardown/about.md
@@ -22,4 +22,18 @@ next!(source, 2) # Logs nothing as a single one actor has unsubscribed
 !!! note
     A Subscription essentially just has its own specific method for `unsubscribe!()` function which releases resources or cancel Observable executions. Any Observable has to return a valid `Teardown` object.
 
+
+`unsubscribe!` function also supports multiple unsubscriptions at once. If the input argument to the `unsubscribe!` function is a tuple, it will first check that all of the arguments are valid subscription objects and if its true will unsubscribe from each of them individually. However it does not check for exceptions during unsubscription process.
+
+```julia
+
+source = Subject(Int)
+
+subscription1 = subscribe!(source, logger())
+subscription2 = subscribe!(source, logger())
+
+unsubscribe!((subscription1, subscription2))
+
+```
+
 For more information about subscription and teardown logic see the [API Section](@ref teardown_api)

--- a/docs/src/teardown/about.md
+++ b/docs/src/teardown/about.md
@@ -23,7 +23,7 @@ next!(source, 2) # Logs nothing as a single one actor has unsubscribed
     A Subscription essentially just has its own specific method for `unsubscribe!()` function which releases resources or cancel Observable executions. Any Observable has to return a valid `Teardown` object.
 
 
-`unsubscribe!` function also supports multiple unsubscriptions at once. If the input argument to the `unsubscribe!` function is a tuple, it will first check that all of the arguments are valid subscription objects and if its true will unsubscribe from each of them individually. However it does not check for exceptions during unsubscription process.
+`unsubscribe!` function also supports multiple unsubscriptions at once. If the input argument to the `unsubscribe!` function is either a tuple or a vector, it will first check that all of the arguments are valid subscription objects and if its true will unsubscribe from each of them individually.
 
 ```julia
 
@@ -33,6 +33,9 @@ subscription1 = subscribe!(source, logger())
 subscription2 = subscribe!(source, logger())
 
 unsubscribe!((subscription1, subscription2))
+
+# or similarly
+# unsubscribe!([ subscription1, subscription2 ])
 
 ```
 

--- a/src/subscribable.jl
+++ b/src/subscribable.jl
@@ -121,6 +121,8 @@ union_type(::AbstractVector{ <: AbstractSubscribable{T} }) where T = T
 """
     subscribe!(subscribable::T, actor::S)   where { T, S }
     subscribe!(subscribable::T, factory::F) where { T, F <: AbstractActorFactory }
+    subscribe!(subscriptions::Tuple)
+    subscribe!(subscriptions::AbstractVector)
 
 `subscribe!` function is used to attach an actor to subscribable.
 It also checks types of subscribable and actors to be a valid Subscribable and Actor objects respectively.

--- a/src/teardown.jl
+++ b/src/teardown.jl
@@ -82,6 +82,7 @@ as_teardown(::Type{<:Tuple})    = UnsubscribableTeardownLogic()
 """
     unsubscribe!(subscription)
     unsubscribe!(subscriptions::Tuple)
+    unsubscribe!(subscriptions::AbstractVector)
 
 `unsubscribe!` function is used to cancel Observable execution and to dispose any kind of resources used during an Observable execution.
 If the input argument to the `unsubscribe!` function is either a tuple or a vector, it will first check that all of the arguments are valid subscription objects 

--- a/src/teardown.jl
+++ b/src/teardown.jl
@@ -77,7 +77,6 @@ See also: [`Teardown`](@ref), [`TeardownLogic`](@ref)
 """
 as_teardown(::Type)             = InvalidTeardownLogic()
 as_teardown(::Type{<:Function}) = CallableTeardownLogic()
-as_teardown(::Type{<:Tuple})    = UnsubscribableTeardownLogic()
 
 """
     unsubscribe!(subscription)

--- a/test/test_subscribable.jl
+++ b/test/test_subscribable.jl
@@ -84,6 +84,78 @@ using Rocket
         @test actor.events == [ ]
     end
 
+    @testset "multiple subscribe!" begin
+        # Check if subscribe! throws an error for not valid subscribable
+        @test_throws InvalidSubscribableTraitUsageError             subscribe!(DummyType(), void(Any))
+        @test_throws InvalidActorTraitUsageError                    subscribe!(NotImplementedSubscribable(), DummyType())
+        @test_throws MissingOnSubscribeImplementationError          subscribe!(NotImplementedSubscribable(), void(Any))
+        @test_throws MissingOnScheduledSubscribeImplementationError subscribe!(NotImplementedScheduledSubscribable(), void(Any))
+        @test_throws MissingOnSubscribeImplementationError          subscribe!(ExplicitlyDefinedSimpleSubscribable(), void(Any))
+        @test_throws MissingOnScheduledSubscribeImplementationError subscribe!(ExplicitlyDefinedScheduledSubscribable(), void(Any))
+
+        # Check if subscribe! subscribes to a valid subscribable
+        actor = SimpleActor{Int}()
+        @test subscribe!([
+            (ImplementedSimpleSubscribable(), actor),
+        ]) == [ voidTeardown ]
+        @test actor.events == [ 1 ]
+
+        actor1 = SimpleActor{Int}()
+        actor2 = SimpleActor{Int}()
+        @test subscribe!([
+            (ImplementedSimpleSubscribable(), actor1),
+            (ImplementedSimpleSubscribable(), actor2),
+        ]) == [ voidTeardown, voidTeardown ]
+        @test actor1.events == [ 1 ]
+        @test actor2.events == [ 1 ]
+
+        actor = SimpleActor{Int}()
+        @test subscribe!((
+            (ImplementedSimpleSubscribable(), actor),
+        )) === ( voidTeardown, )
+        @test actor.events == [ 1 ]
+
+        actor1 = SimpleActor{Int}()
+        actor2 = SimpleActor{Int}()
+        @test subscribe!((
+            (ImplementedSimpleSubscribable(), actor1),
+            (ImplementedSimpleSubscribable(), actor2),
+        )) === ( voidTeardown, voidTeardown )
+        @test actor1.events == [ 1 ]
+        @test actor2.events == [ 1 ]
+
+        ## 
+        actor = SimpleActor{Int}()
+        @test subscribe!([
+            (ImplementedScheduledSubscribable(), actor),
+        ]) == [ voidTeardown ]
+        @test actor.events == [ 1 ]
+
+        actor1 = SimpleActor{Int}()
+        actor2 = SimpleActor{Int}()
+        @test subscribe!([
+            (ImplementedScheduledSubscribable(), actor1),
+            (ImplementedScheduledSubscribable(), actor2),
+        ]) == [ voidTeardown, voidTeardown ]
+        @test actor1.events == [ 1 ]
+        @test actor2.events == [ 1 ]
+
+        actor = SimpleActor{Int}()
+        @test subscribe!((
+            (ImplementedScheduledSubscribable(), actor),
+        )) === ( voidTeardown, )
+        @test actor.events == [ 1 ]
+
+        actor1 = SimpleActor{Int}()
+        actor2 = SimpleActor{Int}()
+        @test subscribe!((
+            (ImplementedScheduledSubscribable(), actor1),
+            (ImplementedScheduledSubscribable(), actor2),
+        )) === ( voidTeardown, voidTeardown )
+        @test actor1.events == [ 1 ]
+        @test actor2.events == [ 1 ]
+    end
+
     struct NotImplementedFactory <: AbstractActorFactory end
 
     struct ImplementedFactory <: AbstractActorFactory end

--- a/test/test_teardown.jl
+++ b/test/test_teardown.jl
@@ -65,13 +65,11 @@ import Rocket: InvalidTeardownLogicTraitUsageError, InvalidMultipleTeardownLogic
         @test unsubscribe!((ImplementedSubscription(), AnotherDummyType())) === nothing
         @test unsubscribe!((AnotherDummyType(), ImplementedSubscription())) === nothing
         @test unsubscribe!((AnotherDummyType(), AnotherDummyType())) === nothing
-        @test unsubscribe!((AnotherDummyType(), AnotherDummyType(), (ImplementedSubscription(), ImplementedSubscription()))) === nothing
 
         @test unsubscribe!([ ImplementedSubscription(), ImplementedSubscription() ]) === nothing
         @test unsubscribe!([ ImplementedSubscription(), AnotherDummyType() ]) === nothing
         @test unsubscribe!([ AnotherDummyType(), ImplementedSubscription() ]) === nothing
         @test unsubscribe!([ AnotherDummyType(), AnotherDummyType() ]) === nothing
-        @test unsubscribe!([ AnotherDummyType(), AnotherDummyType(), (ImplementedSubscription(), ImplementedSubscription()) ]) === nothing
     end
 
 end

--- a/test/test_teardown.jl
+++ b/test/test_teardown.jl
@@ -57,17 +57,21 @@ import Rocket: InvalidTeardownLogicTraitUsageError, InvalidMultipleTeardownLogic
         # Check if arbitrary dummy type throws an error in unsubscribe!
         @test_throws InvalidMultipleTeardownLogicTraitUsageError unsubscribe!((DummyType(), ImplementedSubscription()))
         @test_throws InvalidMultipleTeardownLogicTraitUsageError unsubscribe!((ImplementedSubscription(), DummyType()))
-
-        #Check if dummy subscription throws an error in unusubscribe!
-        @test_throws MissingOnUnsubscribeImplementationError unsubscribe!((DummySubscription(), ImplementedSubscription()))
-        @test_throws MissingOnUnsubscribeImplementationError unsubscribe!((ImplementedSubscription(), DummySubscription()))
+        @test_throws InvalidMultipleTeardownLogicTraitUsageError unsubscribe!([ DummyType(), ImplementedSubscription() ])
+        @test_throws InvalidMultipleTeardownLogicTraitUsageError unsubscribe!([ ImplementedSubscription(), DummyType() ])
 
         #Check if implemented subscription calls on_unsubscribe!
-        @test unsubscribe!((ImplementedSubscription(), ImplementedSubscription())) === ("unsubscribed", "unsubscribed")
-        @test unsubscribe!((ImplementedSubscription(), AnotherDummyType())) === ("unsubscribed", nothing)
-        @test unsubscribe!((AnotherDummyType(), ImplementedSubscription())) === (nothing, "unsubscribed")
-        @test unsubscribe!((AnotherDummyType(), AnotherDummyType())) === (nothing, nothing)
-        @test unsubscribe!((AnotherDummyType(), AnotherDummyType(), (ImplementedSubscription(), ImplementedSubscription()))) === (nothing, nothing, ("unsubscribed", "unsubscribed"))
+        @test unsubscribe!((ImplementedSubscription(), ImplementedSubscription())) === nothing
+        @test unsubscribe!((ImplementedSubscription(), AnotherDummyType())) === nothing
+        @test unsubscribe!((AnotherDummyType(), ImplementedSubscription())) === nothing
+        @test unsubscribe!((AnotherDummyType(), AnotherDummyType())) === nothing
+        @test unsubscribe!((AnotherDummyType(), AnotherDummyType(), (ImplementedSubscription(), ImplementedSubscription()))) === nothing
+
+        @test unsubscribe!([ ImplementedSubscription(), ImplementedSubscription() ]) === nothing
+        @test unsubscribe!([ ImplementedSubscription(), AnotherDummyType() ]) === nothing
+        @test unsubscribe!([ AnotherDummyType(), ImplementedSubscription() ]) === nothing
+        @test unsubscribe!([ AnotherDummyType(), AnotherDummyType() ]) === nothing
+        @test unsubscribe!([ AnotherDummyType(), AnotherDummyType(), (ImplementedSubscription(), ImplementedSubscription()) ]) === nothing
     end
 
 end


### PR DESCRIPTION
This PR implements multiple subscriptions/unsubscriptions at once for `subscribe!` and `unsubscribe!` functions.