### PR TITLE
Fix empty combinations of observables

### DIFF
--- a/src/observable/collected.jl
+++ b/src/observable/collected.jl
@@ -13,6 +13,8 @@ Reemits errors from inner observables. Completes when all inner observables comp
 - `sources`: input sources
 - `mappingFn`: optional mappingFn applied to an array of emited values, `copy` by default, should return a Vector
 
+Note: `collectLatest` completes immediatelly if `sources` are empty.
+
 # Optional arguments
 - `::Type{T}`: optional type of emmiting values of inner observables
 - `::Type{R}`: optional return type after applying `mappingFn` to a vector of values
@@ -129,12 +131,16 @@ function on_subscribe!(observable::CollectLatestObservable{L}, actor::A) where {
     wrapper = CollectLatestObservableWrapper(L, actor, storage, observable.mappingFn)
     W       = typeof(wrapper)
 
-    for index in CartesianIndices(axes(sources))
-        @inbounds wrapper.subscriptions[index] = subscribe!(sources[index], CollectLatestObservableInnerActor{L, typeof(index), W}(index, wrapper))
-        if cstatus(wrapper, index) === true && vstatus(wrapper, index) === false
-            dispose(wrapper)
-            break
+    if length(sources) !== 0
+        for index in CartesianIndices(axes(sources))
+            @inbounds wrapper.subscriptions[index] = subscribe!(sources[index], CollectLatestObservableInnerActor{L, typeof(index), W}(index, wrapper))
+            if cstatus(wrapper, index) === true && vstatus(wrapper, index) === false
+                dispose(wrapper)
+                break
+            end
         end
+    else
+        complete!(actor)
     end
 
     if all(wrapper.cstatus)

--- a/src/observable/collected.jl
+++ b/src/observable/collected.jl
@@ -13,7 +13,7 @@ Reemits errors from inner observables. Completes when all inner observables comp
 - `sources`: input sources
 - `mappingFn`: optional mappingFn applied to an array of emited values, `copy` by default, should return a Vector
 
-Note: `collectLatest` completes immediatelly if `sources` are empty.
+Note: `collectLatest` completes immediately if `sources` are empty.
 
 # Optional arguments
 - `::Type{T}`: optional type of emmiting values of inner observables

--- a/src/observable/combined.jl
+++ b/src/observable/combined.jl
@@ -13,6 +13,8 @@ Accept optinal update strategy object.
 - `sources`: input sources
 - `strategy`: optional update strategy for batching new values together
 
+Note: `combineLatest()` completes immediatelly if `sources` are empty.
+
 # Examples
 ```jldoctest
 using Rocket
@@ -137,6 +139,11 @@ function on_subscribe!(observable::CombineLatestObservable{T, S, G}, actor::A) w
     end
 
     return CombineLatestSubscription(wrapper)
+end
+
+function __combine_latest_unrolled_fill_subscriptions!(::Tuple{}, wrapper::CombineLatestActorWrapper)
+    # Fallback for empty `combineLatest`
+    complete!(wrapper.actor)
 end
 
 @unroll function __combine_latest_unrolled_fill_subscriptions!(sources, wrapper::W) where { W <: CombineLatestActorWrapper }

--- a/src/observable/combined.jl
+++ b/src/observable/combined.jl
@@ -13,7 +13,7 @@ Accept optinal update strategy object.
 - `sources`: input sources
 - `strategy`: optional update strategy for batching new values together
 
-Note: `combineLatest()` completes immediatelly if `sources` are empty.
+Note: `combineLatest()` completes immediately if `sources` are empty.
 
 # Examples
 ```jldoctest

--- a/src/observable/combined_updates.jl
+++ b/src/observable/combined_updates.jl
@@ -12,7 +12,7 @@ import Base: show
 - `sources`: input sources
 - `strategy`: optional update strategy for batching new values together
 
-Note: `combineLatestUpdates()` completes immediatelly if `sources` are empty.
+Note: `combineLatestUpdates()` completes immediately if `sources` are empty.
 
 See also: [`Subscribable`](@ref), [`subscribe!`](@ref), [`PushEach`](@ref), [`PushEachBut`](@ref), [`PushNew`](@ref), [`PushNewBut`](@ref), [`PushStrategy`](@ref)
 """

--- a/src/observable/combined_updates.jl
+++ b/src/observable/combined_updates.jl
@@ -12,6 +12,8 @@ import Base: show
 - `sources`: input sources
 - `strategy`: optional update strategy for batching new values together
 
+Note: `combineLatestUpdates()` completes immediatelly if `sources` are empty.
+
 See also: [`Subscribable`](@ref), [`subscribe!`](@ref), [`PushEach`](@ref), [`PushEachBut`](@ref), [`PushNew`](@ref), [`PushNewBut`](@ref), [`PushStrategy`](@ref)
 """
 function combineLatestUpdates end
@@ -101,6 +103,11 @@ function on_subscribe!(observable::CombineLatestUpdatesObservable{S, G}, actor::
     end
 
     return CombineLatestUpdatesSubscription(wrapper)
+end
+
+function __combine_latest_updates_unrolled_fill_subscriptions!(::Tuple{}, wrapper::CombineLatestUpdatesActorWrapper)
+    # Fallback for empty `combineLatest`
+    complete!(wrapper.actor)
 end
 
 @unroll function __combine_latest_updates_unrolled_fill_subscriptions!(sources, wrapper::W) where { W <: CombineLatestUpdatesActorWrapper }

--- a/test/observable/test_observable_collect_latest.jl
+++ b/test/observable/test_observable_collect_latest.jl
@@ -80,6 +80,11 @@ include("../test_helpers.jl")
             values = @ts([ [ 1 2.0; 3.0 4 ], c ]),
             source_type = Matrix{Union{Int, Float64}}
         ),
+        (
+            source      = collectLatest([]),
+            values      = @ts(c),
+            source_type = Vector{Union{}}
+        )
     ])
 
     somenumbers    = Union{Float64, Int}[ 1, 1, 1, 1, 1.0, 1.0, 1.0, 1.0 ]

--- a/test/observable/test_observable_combine_latest.jl
+++ b/test/observable/test_observable_combine_latest.jl
@@ -109,6 +109,16 @@ include("../test_helpers.jl")
             values = @ts(e("err1")),
             source_type = Tuple{Float64, Float64}
         ),
+        (
+            source      = combineLatest((), PushNew()),
+            values      = @ts(c),
+            source_type = Tuple{}
+        ),
+        (
+            source      = combineLatest((), PushEach()),
+            values      = @ts(c),
+            source_type = Tuple{}
+        )
     ])
 
     somenumbers    = [ [ 1 for i in 1:50 ]..., [ 1.0 for i in 1:50 ]... ]

--- a/test/observable/test_observable_combine_updates.jl
+++ b/test/observable/test_observable_combine_updates.jl
@@ -64,6 +64,16 @@ include("../test_helpers.jl")
             values = @ts(e("err1")),
             source_type = Tuple{ typeof(faulted(Float64, "err1")) , typeof(faulted(Float64, "err2")) }
         ),
+        (
+            source      = combineLatestUpdates((), PushNew()),
+            values      = @ts(c),
+            source_type = Tuple{}
+        ),
+        (
+            source      = combineLatestUpdates((), PushEach()),
+            values      = @ts(c),
+            source_type = Tuple{}
+        )
     ])
 
     @testset begin


### PR DESCRIPTION
This PR fixes empty combinations of observables. For convenience empty combinations of observables send completion event immediately. 