### PR TITLE
feat: extend `default_if_empty` to accept callback

### DIFF
--- a/src/operators/default_if_empty.jl
+++ b/src/operators/default_if_empty.jl
@@ -4,9 +4,11 @@ import Base: show
 
 """
     default_if_empty(value::T)
+    default_if_empty(callback::Function)
 
 Creates a `default_if_empty` operator, which emits a given value if the source Observable completes
-without emitting any next value, otherwise mirrors the source Observable.
+without emitting any next value, otherwise mirrors the source Observable. Optionally accepts a zero-argument callback that will be executed to generate default value.
+Note: Callback function's output is always `convert`ed to the `eltype` of the original observable.
 
 ```jldoctest
 using Rocket
@@ -20,45 +22,71 @@ subscribe!(source, logger())
 [LogActor] Data: 0
 [LogActor] Completed
 ```
+
+```jldoctest
+using Rocket
+
+source = completed(Int) |> default_if_empty(() -> 42)
+
+subscribe!(source, logger())
+;
+
+# output
+[LogActor] Data: 42
+[LogActor] Completed
+```
+
 See also: [`AbstractOperator`](@ref), [`InferableOperator`](@ref), [`logger`](@ref), [`map`](@ref)
 """
-default_if_empty(value::T) where T = DefaultIfEmptyOperator{T}(value)
+default_if_empty(value_or_callback::T) where T = DefaultIfEmptyOperator{T}(value_or_callback)
 
 struct DefaultIfEmptyOperator{T} <: InferableOperator
-    value :: T
+    value_or_callback :: T
 end
 
-operator_right(operator::DefaultIfEmptyOperator{T}, ::Type{L}) where { L, T } = Union{L, T}
+operator_right(::DefaultIfEmptyOperator{T}, ::Type{L}) where { L, T }             = Union{L, T}
+operator_right(::DefaultIfEmptyOperator{T}, ::Type{L}) where { L, T <: Function } = L
 
 function on_call!(::Type{L}, ::Type{Union{L, T}}, operator::DefaultIfEmptyOperator{T}, source) where { L, T }
-    return proxy(Union{L, T}, source, DefaultIfEmptyProxy{Union{L, T}}(convert(Union{L, T}, operator.value)))
+    return proxy(Union{L, T}, source, DefaultIfEmptyProxy{Union{L, T}, T}(convert(Union{L, T}, operator.value_or_callback)))
 end
 
-struct DefaultIfEmptyProxy{L} <: ActorProxy
-    default :: L
+function on_call!(::Type{L}, ::Type{L}, operator::DefaultIfEmptyOperator{T}, source) where { L, T <: Function }
+    return proxy(L, source, DefaultIfEmptyProxy{L, T}(operator.value_or_callback))
 end
 
-actor_proxy!(::Type, proxy::DefaultIfEmptyProxy{L}, actor::A) where { L, A } = DefaultIfEmptyActor{L, A}(actor, false, proxy.default)
-
-mutable struct DefaultIfEmptyActor{L, A} <: Actor{L}
-    actor      :: A
-    is_emitted :: Bool
-    default    :: L
+struct DefaultIfEmptyProxy{L, T} <: ActorProxy
+    default_or_callback :: T
 end
+
+actor_proxy!(::Type, proxy::DefaultIfEmptyProxy{L, T}, actor::A) where { L, A, T } = DefaultIfEmptyActor{L, A, T}(actor, false, proxy.default_or_callback)
+
+mutable struct DefaultIfEmptyActor{L, A, T} <: Actor{L}
+    actor               :: A
+    is_emitted          :: Bool
+    default_or_callback :: T
+end
+
+is_emmited(actor::DefaultIfEmptyActor)   = actor.is_emitted
+set_emmited!(actor::DefaultIfEmptyActor) = actor.is_emitted = true
+
+release!(::DefaultIfEmptyActor{L}, callback::Function, actor) where { L } = next!(actor, convert(L, callback()))
+release!(::DefaultIfEmptyActor{L}, default::L, actor) where { L }         = next!(actor, default)
 
 function on_next!(actor::DefaultIfEmptyActor{L}, data::L) where L
-    actor.is_emitted = true
+    set_emmited!(actor)
     next!(actor.actor, data)
 end
 
 function on_error!(actor::DefaultIfEmptyActor, err)
-    actor.is_emitted = true
+    set_emmited!(actor)
     error!(actor.actor, err)
 end
 
 function on_complete!(actor::DefaultIfEmptyActor)
-    if !actor.is_emitted
-        next!(actor.actor, actor.default)
+    if !is_emmited(actor)
+        set_emmited!(actor)
+        release!(actor, actor.default_or_callback, actor.actor)
     end
     complete!(actor.actor)
 end

--- a/test/operators/test_operator_default_if_empty.jl
+++ b/test/operators/test_operator_default_if_empty.jl
@@ -10,6 +10,7 @@ include("../test_helpers.jl")
     println("Testing: operator default_if_empty()")
 
     run_proxyshowcheck("DefaultIfEmpty", default_if_empty(0))
+    run_proxyshowcheck("DefaultIfEmpty", default_if_empty(() -> 0))
 
     run_testset([
         (
@@ -34,7 +35,52 @@ include("../test_helpers.jl")
             source      = completed(Int) |> default_if_empty("string") |> default_if_empty(0) ,
             values      = @ts([ "string", c ]),
             source_type = Union{Int, String}
-        )
+        ),
+        (
+            source = from(1:5) |> default_if_empty(() -> 0),
+            values = @ts([ 1:5, c ]),
+            source_type = Int,
+        ),
+        (
+            source = completed(Int) |> default_if_empty(() -> 0),
+            values = @ts([ 0, c ]),
+            source_type = Int,
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(() -> 0) |> default_if_empty(() -> 1),
+            values      = @ts([ 0, c ]),
+            source_type = Int
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(() -> 1) |> default_if_empty(() -> 0) ,
+            values      = @ts([ 1, c ]),
+            source_type = Int
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(0) |> default_if_empty(() -> 1),
+            values      = @ts([ 0, c ]),
+            source_type = Int
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(1) |> default_if_empty(() -> 0) ,
+            values      = @ts([ 1, c ]),
+            source_type = Int
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(() -> 0) |> default_if_empty(1),
+            values      = @ts([ 0, c ]),
+            source_type = Int
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(() -> 1) |> default_if_empty(0) ,
+            values      = @ts([ 1, c ]),
+            source_type = Int
+        ),
+        (
+            source      = completed(Int) |> default_if_empty(() -> error("42")) |> safe(),
+            values      = @ts(e),
+            source_type = Int
+        ),
     ])
 
 end


### PR DESCRIPTION
This PR extends `default_if_empty` operator to accept value-generating callback.