### PR TITLE
fix: fix take with sync streams

### DIFF
--- a/src/operators/take.jl
+++ b/src/operators/take.jl
@@ -68,8 +68,8 @@ end
 function on_next!(actor::TakeActor{L}, data::L) where L
     if !actor.isdisposed
         if actor.count < actor.maxcount
-            next!(actor.actor, data)
             actor.count += 1
+            next!(actor.actor, data)
             if actor.count == actor.maxcount
                 complete!(actor)
             end

--- a/test/operators/test_operator_take.jl
+++ b/test/operators/test_operator_take.jl
@@ -42,6 +42,23 @@ include("../test_helpers.jl")
         )
     ])
 
+    @testset "Infinite reaction" begin 
+        source = Subject(Int)
+        events = []
+
+        subscription = subscribe!(source |> take(3), lambda(
+            on_next     = (state) -> begin 
+                push!(events, state)
+                next!(source, state + 1)
+            end,
+            on_complete = () -> push!(events, "c")
+        ))
+
+        next!(source, 1)
+
+        @test events == [ 1, 2, 3, "c" ]
+    end
+
 end
 
 end


### PR DESCRIPTION
This PR fixes `take` operator with synchronous self-dependent streams.