### PR TITLE
Method added for RxInfer issue #9

### DIFF
--- a/src/observable/combined.jl
+++ b/src/observable/combined.jl
@@ -7,7 +7,7 @@ import Base: show
     combineLatest(sources::S, strategy::G = PushEach()) where { S <: Tuple, U }
 
 Combines multiple Observables to create an Observable whose values are calculated from the latest values of each of its input Observables.
-Accept optinal update strategy object.
+Accept optimal update strategy object.
 
 # Arguments
 - `sources`: input sources
@@ -128,6 +128,8 @@ end
     sources  :: S
     strategy :: G
 end
+
+getrecent(observable::CombineLatestObservable) = getrecent(observable.sources)
 
 function on_subscribe!(observable::CombineLatestObservable{T, S, G}, actor::A) where { T, S, G, A }
     wrapper = CombineLatestActorWrapper(T, actor, observable.strategy)

--- a/src/observable/connectable.jl
+++ b/src/observable/connectable.jl
@@ -16,6 +16,8 @@ See also: [`connect`](@ref), [`Subscribable`](@ref)
     source  :: S
 end
 
+getrecent(source::ConnectableObservable) = getrecent(source.subject)
+
 function on_subscribe!(observable::ConnectableObservable, actor)
     return subscribe!(observable.subject, actor)
 end

--- a/src/observable/proxy.jl
+++ b/src/observable/proxy.jl
@@ -94,6 +94,11 @@ See also: [`proxy`](@ref)
     proxy          :: P
 end
 
+# TODO Rocket 2.0: Some operators implement custom `getrecent` logic, but in general it is not possible 
+# The `getrecent` is a hidden feature, that is not documented neither exported. It is not a part of the public API and may (read will) change 
+# in the future. We should consider `getrecent` seriously and we depend on this functionlity currently in the `ReactiveMP.jl` package
+getrecent(proxy::ProxyObservable) = getrecent(proxy.proxied_source, proxy.proxy)
+
 function on_subscribe!(observable::ProxyObservable{L}, actor) where L
     return subscribe!(observable.proxied_source, call_actor_proxy!(L, observable.proxy, actor))
 end

--- a/src/operators/map.jl
+++ b/src/operators/map.jl
@@ -57,6 +57,8 @@ struct MapActor{L, A, F} <: Actor{L}
     actor      :: A
 end
 
+getrecent(source, proxy::MapProxy) = proxy.mappingFn(getrecent(source))
+
 on_next!(actor::MapActor{L},  data::L) where L = next!(actor.actor, actor.mappingFn(data))
 on_error!(actor::MapActor, err)                = error!(actor.actor, err)
 on_complete!(actor::MapActor)                  = complete!(actor.actor)

--- a/src/operators/ref_count.jl
+++ b/src/operators/ref_count.jl
@@ -63,6 +63,8 @@ source_proxy!(::Type{L}, proxy::RefCountProxy, source::S) where { L, S } = RefCo
     RefCountSource{L, S}(csource::S) where { L, S } = new(csource, 0, voidTeardown)
 end
 
+getrecent(source::RefCountSource, ::RefCountProxy) = getrecent(source.csource)
+
 function on_subscribe!(refcount_source::RefCountSource, actor)
     subscription = subscribe!(refcount_source.csource, actor)
     refcount_source.refcount += 1


### PR DESCRIPTION
Fixed a small typo and added a `getrecent` method for the `CombineLatest` observable.